### PR TITLE
A few changes were required to make it work for us, plus some refactoring

### DIFF
--- a/teamcity_formatter.rb
+++ b/teamcity_formatter.rb
@@ -1,163 +1,175 @@
+# Adapted from https://github.com/ankurcha/cucumber_teamcity
+
+
+#
+# When running scenario outlines you should run with --extend
+#
+# Possible callbacks:   https://github.com/sedadogan/cucumber/blob/c9f0c382a83b333e0dc3b62b450de54aeb641397/features/formatter_callbacks.feature
+# Documentation:        http://www.rubydoc.info/gems/cucumber/1.2.1/Cucumber/Ast
+# Example of callbacks: https://github.com/sedadogan/cucumber/blob/c9f0c382a83b333e0dc3b62b450de54aeb641397/lib/cucumber/formatter/pretty.rb
+#
+
 class TeamCityFormatter
 
   def initialize(step_mother, io, options)
     @io = io
     @options = options
-    @current_feature_element = nil
+    @current_scenario = nil
     @current_feature = nil
     @current_step=nil
+    @any_scenario_succeeded=false
+    reset_step_counters
 
-    @failed_scenarios = {}
-    @test_output=[]
+    @err_io = StringIO.new
+    $stderr = @err_io
 
-    # we have to store global state to get
-    # our final exit message. Oh, for the want of a destructor.
-    $_TEAMCITY_EXIT_MESSAGE=nil
     at_exit do
-      $stdout.puts $_TEAMCITY_EXIT_MESSAGE unless $_TEAMCITY_EXIT_MESSAGE.nil?
-      $stdout.flush
+      scenario_finish
+      feature_finish
+      raise "No scenario succeeded" if not @any_scenario_succeeded
     end
   end
 
-  def feature_name(name, something)
-    name=name.split("\n").first
-    @current_feature=name if @current_feature.nil?
-    if name != @current_feature
-      feature_finish(@current_feature)
-      @current_feature=name
-    end
-    feature_start(@current_feature)
-  end
-
-  def exception(exception, status)
-    test_failure(@current_step,format_exception(exception)) if status == :failed
-  end
-
-  # put each step into the messages buffer. Because of the way teamcity formats
-  # output, we want to output all our messages at the same time
-  def step_name(keyword, step_match, status, source_indent, background, file_colon_line)
-    line=format_step(keyword, step_match, status)
-    @current_step=line
-    if status != :passed
-      step_message(line, 'WARNING')
-    else
-      step_message(line)
-    end
-    # this has to be (re-)defined here, since cucumber does
-    # not provide hooks at the end of a test(suite), and we want
-    # to let teamcity know we've finished
-    $_TEAMCITY_EXIT_MESSAGE=%Q(
-#{step_messages(:purge => false)}
-##teamcity[testFinished name='#{@current_feature_element}']
-##teamcity[testSuiteFinished name='#{@current_feature}']
-    )
+  def feature_name(the_word_feature, featureName)
+    feature_finish if not @current_feature.nil?
+    feature_start(featureName)
   end
 
   def scenario_name(keyword, name, file_colon_line, source_indent)
-    visit_feature_element_name(keyword, name, file_colon_line, source_indent)
+    if name =~ /\|/
+      # ' | a   | b  | '  =>  '"a", "b"'
+      comma_separated_arguments = name.strip.gsub(/^\|\s*/, '"').gsub(/\s*\|$/, '"').gsub(/\s*\|\s*/, '", "')
+      scenario_name = "#{@scenario_outline} (#{comma_separated_arguments})"
+    else
+      scenario_name = %Q("#{name}")
+    end
+    scenario_finish if not @current_scenario.nil?
+    scenario_start scenario_name
   end
 
-  # Because cucumber does not provide begin and end hooks,
-  # we store the scenario name and issue a Finished when it changes
-  def visit_feature_element_name(keyword, name, file_colon_line, source_indent)
-    # we do not want to treat expanded scenario outlines
-    # as new tests, so we assume anything sarting with a pipe
-    # is a scenario expansion
-    return true if @options[:expand] && name =~ /^|/
-    line = %Q("#{name}")
-    @current_feature_element=line if @current_feature_element.nil?
-    if line != @current_feature_element
-      scenario_finish(@current_feature_element)
-      @current_feature_element=line
+  def step_name(keyword, step_match, status, source_indent, background, file_colon_line)
+    line=format_step(keyword, step_match, status)
+    @current_step=line
+
+    case status
+      when :passed
+        @current_scenario_steps_passed+=1
+      when :failed
+        @current_scenario_steps_failed+=1
+      when :undefined
+        @err_io.puts "The cucumber parser could not understand one of the steps of this test."
+        @current_scenario_steps_failed+=1
+      else
+        @current_scenario_steps_other+=1
     end
-    scenario_start(line)
+
+    step_message(line)
   end
 
   def before_outline_table(outline_table)
-    step_message("#{timestamp_short} running outline: ")
+    @scenario_outline=@current_scenario
+    @scenario_outline_row_number=0
+    scenario_ignore_not_real
+
+    @current_scenario = nil
   end
 
-  def after_table_row(table_row)
-    if table_row.exception
-      test_failure(format_table_row(table_row, :failed),format_exception(table_row.exception))
-    else
-      step_message(format_table_row(table_row))
-    end
+  def exception(exception, status)
+    @err_io.puts format_exception(exception)
   end
 
-  #
-  # = Logging Methods
-  #
 
-  # log the beginning of a feature
-  def feature_start(msg, io=@io)
-    msg=teamcity_escape(msg)
-    io.puts "##teamcity[testSuiteStarted #{timestamp} name='#{msg}']"
-    io.flush
+  ######################################
+  private
+  ######################################
+
+  
+  def feature_start(name)
+    @current_feature=teamcity_escape(name)
+    print_stderr
+    @io.puts "##teamcity[testSuiteStarted #{timestamp} name='#{@current_feature}']"
+    @io.puts "##teamcity[progressMessage 'running feature: #{@current_feature}']"
+    @io.flush
   end
 
-  # log the end of a feature
-  def feature_finish(msg, io=@io)
-    msg=teamcity_escape(msg)
-    io.puts "##teamcity[testSuiteFinished #{timestamp} name='#{msg}']"
-    io.flush
+  def feature_finish
+    print_stderr
+    @io.puts "##teamcity[testSuiteFinished #{timestamp} name='#{@current_feature}']"
+    @io.flush
   end
 
   # log the start of a scenario
-  def scenario_start(msg)
-    msg=teamcity_escape(msg)
-    @io.puts "##teamcity[testStarted #{timestamp} name='#{msg}' captureStandardOutput='true']"
+  def scenario_start(name)
+    @current_scenario=teamcity_escape(name)
+    print_stderr
+    @io.puts "##teamcity[testStarted #{timestamp} name='#{@current_scenario}' captureStandardOutput='true']"
+    @io.puts "##teamcity[progressMessage 'running scenario: #{@current_scenario}']"
     @io.flush
   end
 
-  # log the end of a scenario
-  def scenario_finish(msg)
-    msg=teamcity_escape(msg)
-    @io.puts step_messages(:purge => true)
-    @io.puts "##teamcity[testFinished #{timestamp} name='#{msg}']"
+  def scenario_finish
+    if ((@current_scenario_steps_passed > 0) && (@current_scenario_steps_other == 0) && (@current_scenario_steps_failed == 0))
+      scenario_succeed
+    else
+      scenario_fail(@current_scenario_steps_passed, @current_scenario_steps_other, @current_scenario_steps_failed)
+    end
+    reset_step_counters
+  end
+
+  def scenario_ignore_not_real
+    @io.puts "##teamcity[testIgnored #{timestamp} name='#{@current_scenario}' message='This is a scenario outline, not a real scenario']"
     @io.flush
+    reset_step_counters
+  end
+
+  # log the end of a scenario if succeeded
+  def scenario_succeed
+    @any_scenario_succeeded=true
+    print_stderr
+    @io.puts "##teamcity[testFinished #{timestamp} name='#{@current_scenario}']"
+    @io.flush
+  end
+
+  # log the end of a scenario if failed
+  def scenario_fail(steps_passed, steps_other, steps_failed)
+    print_stderr
+    @io.puts create_scenario_fail_output(@current_scenario, steps_passed, steps_other, steps_failed)
+    @io.puts "##teamcity[testFinished #{timestamp} name='#{@current_scenario}']"
+    @io.flush
+  end
+
+  def create_scenario_fail_output(name, steps_passed, steps_other, steps_failed)
+    print_stderr
+    message="#{steps_passed} steps passed, #{steps_failed} steps failed"
+    message+=", #{steps_other} steps with other statuses" if steps_other > 0
+    return "##teamcity[testFailed #{timestamp} name='#{name}' message='#{message}']"
+  end
+
+  def reset_step_counters
+    @current_scenario_steps_passed = @current_scenario_steps_other = @current_scenario_steps_failed = 0
   end
 
   # add a message from step output to buffer
   # right now, type is ignored, since we have no reasonably
   # attractive way to add that to teamcity
-  def step_message(msg, type = 'NORMAL')
-    @test_output.push(teamcity_escape(msg))
-  end
-
-  # return a string formatted for use by teamcity which includes all messages
-  # if :purge is true (the default), then the buffer is also emptied
-  def step_messages(opt={})
-    purge = opt[:purge].nil? ? true : opt[:purge]
-    ret=''
-    return ret if @test_output.empty?
-    ret=@test_output.join('|n') #teamcity escaped newline
-    @test_output=[] if purge
-    return "##teamcity[message text='|n#{ret}|n']"
-  end
-
-  # Log a test failure
-  def test_failure(msg, details='')
-    # teamcity wants only a single failure per test,
-    # but since tests are scenarios, not steps,
-    # we need to log only once per scenario
-    return unless @failed_scenarios[@current_feature_element].nil?
-    msg=teamcity_escape(msg)
-    details=teamcity_escape(details)
-    name=teamcity_escape(@current_feature_element)
-    @failed_scenarios[@current_feature_element]="#{msg} #{details}"
-    @io.puts "##teamcity[testFailed #{timestamp} name='#{name}' message='#{msg}' details='#{details}']"
+  def step_message(msg)
+    @io.puts "##teamcity[testStdOut name='#{@current_scenario}' out='#{teamcity_escape(msg)}']"
     @io.flush
   end
 
-  private
 
-  # = Formating Methods
+  def print_stderr
+    if not @err_io.string.empty?
+      @io.puts "##teamcity[testStdErr name='#{@current_scenario}' out='#{teamcity_escape(@err_io.string)}']"
+      @err_io.truncate 0
+    end
+  end
+
 
   def format_step(keyword, step_match, status)
     %q{%s %10s %s %-90s @ %s} % [timestamp_short, status, keyword,
-                                     step_match.format_args(lambda{|param| param}),
-                                     step_match.file_colon_line]
+                                 step_match.format_args(lambda { |param| param }),
+                                 step_match.file_colon_line]
   end
 
   def format_exception(exception)


### PR DESCRIPTION
1. No need to save the final output in a global $_TEAMCITY_EXIT_MESSAGE variable. Instead, "at_exit" triggers the final printouts, which enables the code to be better structured.
2. All of stdout and stderr are captured and printed as TeamCity messages.
3. Every scenario outline example is now treated as a separate TeamCity test, and we set the test name to be the name of the outline with the parameters in parentheses. 
4. A scenario fails if some steps are undefined or skipped (before this change success was sometimes unjustified).
5. Some further refactoring, including more meaningful function parameter names.
